### PR TITLE
Debug callback

### DIFF
--- a/src/framework/COScript.h
+++ b/src/framework/COScript.h
@@ -12,6 +12,11 @@
 @class Mocha;
 @class COScript;
 
+
+@protocol CODebugController
+- (void)debug:(NSString*)format args:(va_list)args;
+@end
+
 @interface COScript : NSObject {
     
     Mocha *_mochaRuntime;
@@ -24,7 +29,6 @@
 @property (retain) NSMutableDictionary *env;
 @property (assign) BOOL shouldPreprocess;
 @property (assign) BOOL shouldKeepAround;
-
 
 - (void)cleanup;
 - (void)garbageCollect;
@@ -47,6 +51,8 @@
 + (id)application:(NSString*)app;
 + (id)app:(NSString*)app;
 + (COScript*)currentCOScript;
+
++ (id)setDebugController:(id<CODebugController>)debugController;
 
 @end
 

--- a/src/framework/COScript.h
+++ b/src/framework/COScript.h
@@ -14,7 +14,7 @@
 
 
 @protocol CODebugController
-- (void)debug:(NSString*)format args:(va_list)args;
+- (void)output:(NSString*)format args:(va_list)args;
 @end
 
 @interface COScript : NSObject {

--- a/src/framework/COScript.m
+++ b/src/framework/COScript.m
@@ -17,11 +17,15 @@
 #import "MOUndefined.h"
 #import "MOBridgeSupportController.h"
 
+#import <stdarg.h>
+
 extern int *_NSGetArgc(void);
 extern char ***_NSGetArgv(void);
 
 static BOOL JSTalkShouldLoadJSTPlugins = YES;
 static NSMutableArray *JSTalkPluginList;
+
+static id<CODebugController> CODebugController = nil;
 
 @interface Mocha (Private)
 - (JSValueRef)setObject:(id)object withName:(NSString *)name;
@@ -34,8 +38,25 @@ static NSMutableArray *JSTalkPluginList;
 
 @end
 
+void COScriptDebug(NSString* format, ...) {
+    va_list args;
+    va_start(args, format);
+    if (CODebugController == nil) {
+        NSLogv(format, args);
+    } else {
+        [CODebugController debug:format args:args];
+    }
+
+    va_end(args);
+}
 
 @implementation COScript
+
++ (id)setDebugController:(id)debugController {
+    id oldController = CODebugController;
+    CODebugController = debugController;
+    return oldController;
+}
 
 + (void)listen {
     [COSListener listen];

--- a/src/framework/COScript.m
+++ b/src/framework/COScript.m
@@ -44,7 +44,7 @@ void COScriptDebug(NSString* format, ...) {
     if (CODebugController == nil) {
         NSLogv(format, args);
     } else {
-        [CODebugController debug:format args:args];
+        [CODebugController output:format args:args];
     }
 
     va_end(args);

--- a/src/framework/CocoaScript_Prefix.pch
+++ b/src/framework/CocoaScript_Prefix.pch
@@ -9,7 +9,8 @@
 #endif
 
 #ifdef DEBUG
-    #define debug(...) NSLog(__VA_ARGS__)
+    extern void COScriptDebug(NSString* format, ...) NS_FORMAT_FUNCTION(1,2);
+    #define debug(...) COScriptDebug
 #else
     #define debug(...)
 #endif

--- a/src/framework/CocoaScript_Prefix.pch
+++ b/src/framework/CocoaScript_Prefix.pch
@@ -10,7 +10,7 @@
 
 #ifdef DEBUG
     extern void COScriptDebug(NSString* format, ...) NS_FORMAT_FUNCTION(1,2);
-    #define debug(...) COScriptDebug
+    #define debug COScriptDebug
 #else
     #define debug(...)
 #endif


### PR DESCRIPTION
Adds a [COScript setDebugController] method, which lets you pass in an object that gets to deal with internal debug() calls.

If you don't do anything, this debug output ends up going to NSLog as before.

If you give it a debug controller object, its output:args: method will get called for each debug message. This lets you route the log output differently.
