### PR TITLE
Javascript debugging support

### DIFF
--- a/src/framework/COScript.m
+++ b/src/framework/COScript.m
@@ -295,9 +295,9 @@ NSString *currentCOScriptThreadIdentifier = @"org.jstalk.currentCOScriptHack";
     id resultObj = nil;
     
     @try {
-        
-        resultObj = [_mochaRuntime evalString:str];
-        
+
+        resultObj = [_mochaRuntime evalString:str atURL:base];
+
         if (resultObj == [MOUndefined undefined]) {
             resultObj = nil;
         }

--- a/src/framework/mocha/MochaRuntime.h
+++ b/src/framework/mocha/MochaRuntime.h
@@ -54,6 +54,21 @@
 
 
 /*!
+ * @method evalString:
+ * @abstract Evalutates the specified JavaScript expression, returning the result
+ *
+ * @param string
+ * The JavaScript expression to evaluate
+ *
+ * @param url
+ * The location of the script - used for error reporting and interactive debugging.
+ *
+ * @result An object, or nil
+ */
+- (id)evalString:(NSString *)string atURL:(NSURL*)url;
+
+
+/*!
  * @method callFunctionWithName:
  * @abstract Calls a JavaScript function in the global context
  * 

--- a/src/framework/mocha/MochaRuntime.m
+++ b/src/framework/mocha/MochaRuntime.m
@@ -569,9 +569,9 @@ NSString * const MOAlreadyProtectedKey = @"moAlreadyProtectedKey";
 }
 
 - (id)evalString:(NSString *)string atURL:(NSURL *)url {
-    NSString* name = url ? [[url lastPathComponent] stringByDeletingPathExtension] : @"Untitled Script";
     if (JSGlobalContextSetName != NULL)
     {
+        NSString* name = url ? [[url lastPathComponent] stringByDeletingPathExtension] : @"Untitled Script";
         JSStringRef jsName = JSStringCreateWithUTF8CString([name UTF8String]);
         JSGlobalContextSetName(_ctx, jsName);
         JSStringRelease(jsName);

--- a/src/framework/mocha/MochaRuntime.m
+++ b/src/framework/mocha/MochaRuntime.m
@@ -570,9 +570,12 @@ NSString * const MOAlreadyProtectedKey = @"moAlreadyProtectedKey";
 
 - (id)evalString:(NSString *)string atURL:(NSURL *)url {
     NSString* name = url ? [[url lastPathComponent] stringByDeletingPathExtension] : @"Untitled Script";
-    JSStringRef jsName = JSStringCreateWithUTF8CString([name UTF8String]);
-    JSGlobalContextSetName(_ctx, jsName);
-    JSStringRelease(jsName);
+    if (JSGlobalContextSetName != NULL)
+    {
+        JSStringRef jsName = JSStringCreateWithUTF8CString([name UTF8String]);
+        JSGlobalContextSetName(_ctx, jsName);
+        JSStringRelease(jsName);
+    }
     JSValueRef jsValue = [self evalJSString:string scriptPath:[url path]];
     return [self objectForJSValue:jsValue];
 }

--- a/src/framework/mocha/MochaRuntime.m
+++ b/src/framework/mocha/MochaRuntime.m
@@ -568,6 +568,15 @@ NSString * const MOAlreadyProtectedKey = @"moAlreadyProtectedKey";
     return [self objectForJSValue:jsValue];
 }
 
+- (id)evalString:(NSString *)string atURL:(NSURL *)url {
+    NSString* name = url ? [[url lastPathComponent] stringByDeletingPathExtension] : @"Untitled Script";
+    JSStringRef jsName = JSStringCreateWithUTF8CString([name UTF8String]);
+    JSGlobalContextSetName(_ctx, jsName);
+    JSStringRelease(jsName);
+    JSValueRef jsValue = [self evalJSString:string scriptPath:[url path]];
+    return [self objectForJSValue:jsValue];
+}
+
 - (JSValueRef)evalJSString:(NSString *)string {
     return [self evalJSString:string scriptPath:nil];
 }

--- a/src/framework/mocha/MochaRuntime.m
+++ b/src/framework/mocha/MochaRuntime.m
@@ -569,6 +569,7 @@ NSString * const MOAlreadyProtectedKey = @"moAlreadyProtectedKey";
 }
 
 - (id)evalString:(NSString *)string atURL:(NSURL *)url {
+#ifdef MAC_OS_X_VERSION_10_10
     if (JSGlobalContextSetName != NULL)
     {
         NSString* name = url ? [[url lastPathComponent] stringByDeletingPathExtension] : @"Untitled Script";
@@ -576,6 +577,7 @@ NSString * const MOAlreadyProtectedKey = @"moAlreadyProtectedKey";
         JSGlobalContextSetName(_ctx, jsName);
         JSStringRelease(jsName);
     }
+#endif
     JSValueRef jsValue = [self evalJSString:string scriptPath:[url path]];
     return [self objectForJSValue:jsValue];
 }


### PR DESCRIPTION
Some minor tweaks to pass the script URL through and to set the global context name.

This, plus the addition of the com.apple.security.get-task-allow key to the host application's entitlements, is enough to enable attaching Safari to the javascript for debugging. In theory. On a good day. With a following wind...
