### PR TITLE
MOJavaScriptObject.h import in COSGifAnimatior.h error

### DIFF
--- a/src/framework/COSGifAnimator.h
+++ b/src/framework/COSGifAnimator.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CocoaScript/COScript.h>
-#import <CocoaScript/MOJavaScriptObject.h>
+#import "MOJavaScriptObject.h"
 
 @interface COSGifAnimator : NSObject {
     COScript *_jstalk;


### PR DESCRIPTION
The "#import <CocoaScript/MOJavaScriptObject.h>" throws a compile
error. I changed the line to #import "MOJavaScriptObject.h"  to get the
project compiled.

May be it's an issue with the code and you may be interested in the change.
