### PR TITLE
Add support for recursive imports, absolute paths

### DIFF
--- a/src/framework/COSPreprocessor.m
+++ b/src/framework/COSPreprocessor.m
@@ -216,33 +216,27 @@
                     [tokenizer nextToken]; // the space
                     NSString *pathInQuotes = [[tokenizer nextToken] stringValue];
                     
-                    NSString *path = [pathInQuotes substringWithRange:NSMakeRange(1, [pathInQuotes length]-2)];
+                    NSString *path = [[pathInQuotes substringWithRange:NSMakeRange(1, [pathInQuotes length]-2)] stringByExpandingTildeInPath];
+                    NSURL *importURL = nil;
                     
-                    if (base) {
-                        
-                        NSURL *importURL = [[base URLByDeletingLastPathComponent] URLByAppendingPathComponent:path];
-                        
-                        NSError *outErr = nil;
-                        NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
-                        
-                        if (s) {
-                            [buffer appendFormat:@"// imported from %@", [importURL path]];
-                            [buffer appendString:s];
-                        }
-                        else {
-                            [buffer appendFormat:@"'Unable to import %@ becase %@'", path, [outErr localizedFailureReason]];
-                        }
-                        
-                        
-                        //debug(@"importURL: '%@'", importURL);
-                        
+                    if (base && path.length && ![[path substringWithRange:NSMakeRange(0, 1)] isEqualToString:@"/"]) {
+                        importURL = [[base URLByDeletingLastPathComponent] URLByAppendingPathComponent:path];
+                    } else {
+                        importURL = [NSURL fileURLWithPath:path];
+                    }
+                    
+                    NSError *outErr = nil;
+                    NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
+                    
+                    if (s) {
+                        [buffer appendFormat:@"// imported from %@", [importURL path]];
+                        [buffer appendString:s];
                     }
                     else {
-                        [buffer appendFormat:@"'Unable to import %@ becase we have no base url to import from'", path];
+                        [buffer appendFormat:@"'Unable to import %@ because %@'", path, [outErr localizedFailureReason]];
                     }
                     
                     debug(@"[tok stringValue]: '%@'", path);
-                    
                     
                     continue;
                 }

--- a/src/framework/COSPreprocessor.m
+++ b/src/framework/COSPreprocessor.m
@@ -219,21 +219,25 @@
                     NSString *path = [[pathInQuotes substringWithRange:NSMakeRange(1, [pathInQuotes length]-2)] stringByExpandingTildeInPath];
                     NSURL *importURL = nil;
                     
-                    if (base && path.length && ![[path substringWithRange:NSMakeRange(0, 1)] isEqualToString:@"/"]) {
+                    if (path.length && ![[path substringWithRange:NSMakeRange(0, 1)] isEqualToString:@"/"]) {
                         importURL = [[base URLByDeletingLastPathComponent] URLByAppendingPathComponent:path];
-                    } else {
+                    } else if (base) {
                         importURL = [NSURL fileURLWithPath:path];
+                    } else {
+                        [buffer appendFormat:@"'Unable to import %@ becase we have no base url to import from'", path];
                     }
                     
-                    NSError *outErr = nil;
-                    NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
-                    
-                    if (s) {
-                        [buffer appendFormat:@"// imported from %@", [importURL path]];
-                        [buffer appendString:s];
-                    }
-                    else {
-                        [buffer appendFormat:@"'Unable to import %@ because %@'", path, [outErr localizedFailureReason]];
+                    if (importURL) {
+                        NSError *outErr = nil;
+                        NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
+                        
+                        if (s) {
+                            [buffer appendFormat:@"// imported from %@", [importURL path]];
+                            [buffer appendString:s];
+                        }
+                        else {
+                            [buffer appendFormat:@"'Unable to import %@ because %@'", path, [outErr localizedFailureReason]];
+                        }                        
                     }
                     
                     debug(@"[tok stringValue]: '%@'", path);

--- a/src/framework/COSPreprocessor.m
+++ b/src/framework/COSPreprocessor.m
@@ -228,7 +228,7 @@
                     
                     if (importURL) {
                         if ([importedURLs containsObject:importURL]) {
-                            [buffer appendFormat:@"// skipping already imported file from %@", [importURL path]];
+                            [buffer appendFormat:@"// skipping already imported file from %@\n", [importURL path]];
                         } else {
                             NSError *outErr = nil;
                             NSString *s = [NSString stringWithContentsOfURL:importURL encoding:NSUTF8StringEncoding error:&outErr];
@@ -237,7 +237,7 @@
                                 [importedURLs addObject:importURL];
                                 s = [self processImports:s withBaseURL:base importedURLs:importedURLs];
                                 
-                                [buffer appendFormat:@"// imported from %@", [importURL path]];
+                                [buffer appendFormat:@"// imported from %@\n", [importURL path]];
                                 [buffer appendString:s];
                             }
                             else {


### PR DESCRIPTION
Sketch.app previously used its own script import syntax (`#import`). We're now switching to CocoaScript's native `@import` syntax.

This PR adds support we previously enjoyed for:
- Absolute script paths (`/path/to/script`) 
- Script paths relative to home folder (`~/path/to/script`)
- Nested imports, with a guard against circular / recursive imports

There's also a bug in the current implementation which ignores the first line of an imported script. I've addressed that too. Let me know if you would rather split this into multiple PRs.
