### PR TITLE
fix Mocha_getProperty for macOS 10.13.2

### DIFF
--- a/src/framework/mocha/MochaRuntime.m
+++ b/src/framework/mocha/MochaRuntime.m
@@ -1071,7 +1071,7 @@ JSValueRef Mocha_getProperty(JSContextRef ctx, JSObjectRef object, JSStringRef p
     // ObjC class
     //
     Class objCClass = NSClassFromString(propertyName);
-    if (objCClass && ![propertyName isEqualToString:@"Object"]) {
+    if (objCClass && ![propertyName isEqualToString:@"Object"] && ![propertyName isEqualToString:@"Function"]) {
         JSValueRef ret = [runtime JSValueForObject:objCClass];
         
         if (!objc_getAssociatedObject(objCClass, &MOAlreadyProtectedKey)) {


### PR DESCRIPTION
macOS 10.13.2 has a new class called `Function` so we need
to explicitly check for it, same way as we were checking
for `Object`