### PR TITLE
Keep track of background tasks

### DIFF
--- a/Cocoa Script.xcodeproj/project.pbxproj
+++ b/Cocoa Script.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		031EFEF71FD59089000B5798 /* COScript+Fiber.h in Headers */ = {isa = PBXBuildFile; fileRef = 031EFEF11FD57DC6000B5798 /* COScript+Fiber.h */; };
+		031EFEF81FD5909D000B5798 /* COSFiber.h in Headers */ = {isa = PBXBuildFile; fileRef = 031EFEF41FD5864C000B5798 /* COSFiber.h */; };
+		031EFEF91FD590B6000B5798 /* COSFiber.m in Sources */ = {isa = PBXBuildFile; fileRef = 031EFEF51FD5864C000B5798 /* COSFiber.m */; };
+		031EFEFA1FD590C0000B5798 /* COScript+Fiber.m in Sources */ = {isa = PBXBuildFile; fileRef = 031EFEF21FD57DC6000B5798 /* COScript+Fiber.m */; };
 		384830E21832D48500B34168 /* COSTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 384830E01832D48500B34168 /* COSTarget.h */; };
 		384830E31832D48500B34168 /* COSTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 384830E11832D48500B34168 /* COSTarget.m */; };
 		8D15AC340486D014006FF6A4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */; };
@@ -407,6 +411,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		031EFEF11FD57DC6000B5798 /* COScript+Fiber.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "COScript+Fiber.h"; path = "src/framework/COScript+Fiber.h"; sourceTree = "<group>"; };
+		031EFEF21FD57DC6000B5798 /* COScript+Fiber.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "COScript+Fiber.m"; path = "src/framework/COScript+Fiber.m"; sourceTree = "<group>"; };
+		031EFEF41FD5864C000B5798 /* COSFiber.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = COSFiber.h; path = src/framework/COSFiber.h; sourceTree = "<group>"; };
+		031EFEF51FD5864C000B5798 /* COSFiber.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = COSFiber.m; path = src/framework/COSFiber.m; sourceTree = "<group>"; };
 		1058C7A7FEA54F5311CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		13E42FBA07B3F13500E4EEF1 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
 		2A37F4C4FDCFA73011CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
@@ -1073,6 +1081,10 @@
 		CCA1A532183EA838000159B3 /* helpers */ = {
 			isa = PBXGroup;
 			children = (
+				031EFEF41FD5864C000B5798 /* COSFiber.h */,
+				031EFEF51FD5864C000B5798 /* COSFiber.m */,
+				031EFEF11FD57DC6000B5798 /* COScript+Fiber.h */,
+				031EFEF21FD57DC6000B5798 /* COScript+Fiber.m */,
 				CCA1A533183EA86E000159B3 /* COSInterval.h */,
 				CCA1A534183EA86E000159B3 /* COSInterval.m */,
 				CC847AFA183EE02300436C38 /* COScript+Interval.h */,
@@ -1221,6 +1233,8 @@
 			files = (
 				CC66D81E181A2A710039A0A5 /* COScript.h in Headers */,
 				CC66D89C181A2B0A0039A0A5 /* MOAllocator.h in Headers */,
+				031EFEF81FD5909D000B5798 /* COSFiber.h in Headers */,
+				031EFEF71FD59089000B5798 /* COScript+Fiber.h in Headers */,
 				CC66D80E181A2A470039A0A5 /* TDWhitespaceState.h in Headers */,
 				CC66D812181A2A470039A0A5 /* TDWordOrReservedState.h in Headers */,
 				CC66D868181A2AE10039A0A5 /* MochaDefines.h in Headers */,
@@ -1515,6 +1529,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				031EFEFA1FD590C0000B5798 /* COScript+Fiber.m in Sources */,
+				031EFEF91FD590B6000B5798 /* COSFiber.m in Sources */,
 				CC66D83D181A2A9B0039A0A5 /* COSOpenCLProgram.m in Sources */,
 				CC66D7DA181A2A470039A0A5 /* TDNum.m in Sources */,
 				CC66D7C8181A2A470039A0A5 /* TDComment.m in Sources */,

--- a/src/editor/JSTDocument.m
+++ b/src/editor/JSTDocument.m
@@ -210,7 +210,7 @@
         }
     }
     
-    if (![jstalk shouldKeepAround]) {
+    if (![jstalk shouldKeepAround] && ![jstalk hasActiveFibers]) {
         [jstalk cleanup];
     }
     

--- a/src/framework/COSFiber.h
+++ b/src/framework/COSFiber.h
@@ -1,0 +1,24 @@
+//
+//  COSFiber.h
+//  Cocoa Script
+//
+//  Created by Mathieu Dutour on 12/04/17.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+#import "MOJavaScriptObject.h"
+#import <CocoaScript/COScript.h>
+
+@interface COSFiber : NSObject
+
+@property (weak) COScript *coscript;
+@property (strong) MOJavaScriptObject *cleanUpJSfunc;
+
++ (id)createWithCocoaScript:(COScript*)cos;
+- (void)onCleanup:(MOJavaScriptObject *)jsFunction;
+- (void)cleanup;
+
+@end
+

--- a/src/framework/COSFiber.m
+++ b/src/framework/COSFiber.m
@@ -1,0 +1,37 @@
+//
+//  COSFiber.m
+//  Cocoa Script Editor
+//
+//  Created by Mathieu Dutour on 04/12/2017.
+//
+
+#import "COSFiber.h"
+#import "COScript+Fiber.h"
+
+@implementation COSFiber
++ (id)createWithCocoaScript:(COScript *)cos {
+    
+    COSFiber *fiber = [[[self class] alloc] init];
+    
+    [fiber setCoscript:cos];
+    
+    return fiber;
+    
+}
+
+- (void)onCleanup:(MOJavaScriptObject *)jsFunction {
+    _cleanUpJSfunc = jsFunction;
+}
+
+- (void)cleanup {
+    if (_cleanUpJSfunc != nil) {
+        [_coscript callJSFunction:[_cleanUpJSfunc JSObject] withArgumentsInArray:@[]];
+    }
+    
+    [_coscript removeFiber:self];
+    
+    _cleanUpJSfunc = nil;
+    _coscript = nil;
+}
+
+@end

--- a/src/framework/COSInterval.h
+++ b/src/framework/COSInterval.h
@@ -13,7 +13,7 @@
 #import "COSFiber.h"
 
 @interface COSInterval : COSFiber {
-    
+    MOJavaScriptObject *_jsfunc;
     NSTimer *_timer;
     BOOL _onshot;
 }

--- a/src/framework/COSInterval.h
+++ b/src/framework/COSInterval.h
@@ -10,14 +10,14 @@
 
 #import "MOJavaScriptObject.h"
 #import <CocoaScript/COScript.h>
+#import "COSFiber.h"
 
-@interface COSInterval : NSObject {
+@interface COSInterval : COSFiber {
     
     NSTimer *_timer;
     BOOL _onshot;
 }
 
-@property (weak) COScript *coscript;
 @property (strong) MOJavaScriptObject *jsfunc;
 
 + (id)scheduleWithInterval:(NSTimeInterval)i cocoaScript:(COScript*)cos jsFunction:(MOJavaScriptObject *)jsFunction repeat:(BOOL)repeat;

--- a/src/framework/COSInterval.m
+++ b/src/framework/COSInterval.m
@@ -13,9 +13,9 @@
 
 + (id)scheduleWithInterval:(NSTimeInterval)i cocoaScript:(COScript*)cos jsFunction:(MOJavaScriptObject *)jsFunction repeat:(BOOL)repeat {
     
-    COSInterval *interval = [COSFiber createWithCocoaScript: cos];
+    COSInterval *interval = [COSInterval createWithCocoaScript: cos];
     
-    [interval setJsfunc:jsFunction];
+    interval->_jsfunc = jsFunction;
     
     NSTimer *t = [NSTimer scheduledTimerWithTimeInterval:i target:interval selector:@selector(timerHit:) userInfo:nil repeats:repeat];
     

--- a/src/framework/COSInterval.m
+++ b/src/framework/COSInterval.m
@@ -7,15 +7,15 @@
 //
 
 #import "COSInterval.h"
-#import "COScript+Interval.h"
+#import "COSFiber.h"
+
 @implementation COSInterval
 
 + (id)scheduleWithInterval:(NSTimeInterval)i cocoaScript:(COScript*)cos jsFunction:(MOJavaScriptObject *)jsFunction repeat:(BOOL)repeat {
     
-    COSInterval *interval = [[[self class] alloc] init];
+    COSInterval *interval = [COSFiber createWithCocoaScript: cos];
     
     [interval setJsfunc:jsFunction];
-    [interval setCoscript:cos];
     
     NSTimer *t = [NSTimer scheduledTimerWithTimeInterval:i target:interval selector:@selector(timerHit:) userInfo:nil repeats:repeat];
     
@@ -33,10 +33,9 @@
 
 - (void)cleanup {
     
-    [_coscript removeInterval:self];
+    [super cleanup];
     
     _jsfunc = nil;
-    _coscript = nil;
 }
 
 - (void)cancel {
@@ -48,7 +47,7 @@
 
 - (void)timerHit:(NSTimer*)timer {
     
-    [_coscript callJSFunction:[_jsfunc JSObject] withArgumentsInArray:@[self]];
+    [self.coscript callJSFunction:[_jsfunc JSObject] withArgumentsInArray:@[self]];
     
     if (_onshot) {
         [self cancel];

--- a/src/framework/COScript+Fiber.h
+++ b/src/framework/COScript+Fiber.h
@@ -1,0 +1,19 @@
+//
+//  COScript+Fiber.h
+//  Cocoa Script
+//
+//  Created by Mathieu Dutour on 12/04/17.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <CocoaScript/COScript.h>
+
+@class COSFiber;
+
+@interface COScript (FiberAdditions)
+- (void)addFiber:(COSFiber*)fiber;
+- (void)cleanupFibers;
+- (void)removeFiber:(COSFiber*)fiber;
+@end
+

--- a/src/framework/COScript+Fiber.m
+++ b/src/framework/COScript+Fiber.m
@@ -1,0 +1,51 @@
+//
+//  COScript+Fiber.m
+//  Cocoa Script
+//
+//  Created by Mathieu Dutour on 12/04/17.
+//
+//
+
+#import "COScript+Fiber.h"
+#import "COSFiber.h"
+
+@implementation COScript (FiberAdditions)
+
+- (void)addFiber:(COSFiber*)fiber {
+    
+    if (!_activeFibers) {
+        _activeFibers = [NSMutableArray array];
+    }
+    
+    [_activeFibers addObject:fiber];
+}
+
+- (void)cleanupFibers {
+    for (COSFiber *fiber in _activeFibers) {
+        [fiber cleanup];
+    }
+
+    [_activeFibers removeAllObjects];
+    _activeFibers = nil;
+}
+
+- (void)removeFiber:(COSFiber*)fiber {
+    
+    if ([_activeFibers indexOfObject:fiber] == NSNotFound) {
+        NSLog(@"Could not clean up fiber %@ because it is not in %@'s fiber stack.", fiber, self);
+        return;
+    }
+    
+    [_activeFibers removeObject:fiber];
+}
+
+- (id)createFiber {
+    
+    COSFiber *fiber = [COSFiber createWithCocoaScript:self];
+    [self addFiber:fiber];
+    
+    return fiber;
+}
+
+@end
+

--- a/src/framework/COScript+Interval.h
+++ b/src/framework/COScript+Interval.h
@@ -1,5 +1,5 @@
 //
-//  COSScript+Interval.h
+//  COScript+Interval.h
 //  Cocoa Script
 //
 //  Created by August Mueller on 11/21/13.
@@ -12,6 +12,4 @@
 @class COSInterval;
 
 @interface COScript (IntervalAdditions)
-- (void)cleanupIntervals;
-- (void)removeInterval:(COSInterval*)interval;
 @end

--- a/src/framework/COScript+Interval.m
+++ b/src/framework/COScript+Interval.m
@@ -7,45 +7,15 @@
 //
 
 #import "COScript+Interval.h"
+#import "COScript+Fiber.h"
 #import "COSInterval.h"
 
 @implementation COScript (IntervalAdditions)
 
-- (void)addInterval:(COSInterval*)i {
-    
-    if (!_intervals) {
-        _intervals = [NSMutableArray array];
-    }
-    
-    [_intervals addObject:i];
-}
-
-- (void)cleanupIntervals {
-    
-    for (COSInterval *i in _intervals) {
-        [i cancel];
-    }
-    
-    [_intervals removeAllObjects];
-    
-    _intervals = nil;
-    
-}
-
-- (void)removeInterval:(COSInterval*)interval {
-    
-    if ([_intervals indexOfObject:interval] == NSNotFound) {
-        NSLog(@"Could not remove interval %@ because it is not in %@'s interval stack.", interval, self);
-        return;
-    }
-    
-    [_intervals removeObject:interval];
-}
-
 - (id)scheduleWithRepeatingInterval:(NSTimeInterval)i jsFunction:(MOJavaScriptObject *)jsFunction {
     
     COSInterval *cosi = [COSInterval scheduleWithInterval:i cocoaScript:self jsFunction:jsFunction repeat:YES];
-    [self addInterval:cosi];
+    [self addFiber:cosi];
     
     return cosi;
 }
@@ -53,10 +23,9 @@
 - (id)scheduleWithInterval:(NSTimeInterval)i jsFunction:(MOJavaScriptObject *)jsFunction {
     
     COSInterval *cosi = [COSInterval scheduleWithInterval:i cocoaScript:self jsFunction:jsFunction repeat:NO];
-    [self addInterval:cosi];
+    [self addFiber:cosi];
     
     return cosi;
 }
-
 
 @end

--- a/src/framework/COScript.h
+++ b/src/framework/COScript.h
@@ -21,7 +21,9 @@
     
     Mocha *_mochaRuntime;
     
-    NSMutableArray *_intervals;
+    // used in COScript+Fiber
+    NSMutableArray *_activeFibers;
+    int _nextFiberId;
 }
 
 @property (weak) id printController;
@@ -37,6 +39,7 @@
 - (void)pushObject:(id)obj withName:(NSString*)name;
 - (void)deleteObjectWithName:(NSString*)name;
 - (void)print:(NSString*)s;
+- (BOOL)shouldKeepRunning;
 
 - (JSGlobalContextRef)context;
 - (id)callFunctionNamed:(NSString*)name withArguments:(NSArray*)args;

--- a/src/framework/COScript.m
+++ b/src/framework/COScript.m
@@ -9,6 +9,7 @@
 #import "COScript.h"
 #import "COSListener.h"
 #import "COSPreprocessor.h"
+#import "COScript+Fiber.h"
 #import "COScript+Interval.h"
 
 #import <ScriptingBridge/ScriptingBridge.h>
@@ -91,7 +92,7 @@ void COScriptDebug(NSString* format, ...) {
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     
-    [self cleanupIntervals];
+    [self cleanupFibers];
     
 }
 
@@ -112,6 +113,16 @@ void COScriptDebug(NSString* format, ...) {
     [_mochaRuntime garbageCollect];
     
     debug(@"gc took %f seconds", [NSDate timeIntervalSinceReferenceDate] - start);
+}
+
+- (BOOL)shouldKeepRunning {
+    if (_shouldKeepAround) {
+        return YES;
+    }
+    if (_activeFibers != nil) {
+        return [_activeFibers count] > 0;
+    }
+    return NO;
 }
 
 


### PR DESCRIPTION
As of today, the only way to keep a script alive while doing some async work is to use `coScript.shouldKeepAround`.
The issue is that there is no (easy) way to schedule more than one background tasks without closing the others when one is finished.

Each background task should create its own "fiber" and `shouldKeepRunning` returns whether some fibers are still active or not.