### PR TITLE
fix missing stack traces when not preprocessing

### DIFF
--- a/src/framework/COScript.m
+++ b/src/framework/COScript.m
@@ -331,13 +331,12 @@ NSString *currentCOScriptThreadIdentifier = @"org.jstalk.currentCOScriptHack";
     if (!JSTalkPluginList && JSTalkShouldLoadJSTPlugins) {
         [COScript loadPlugins];
     }
+	
+    if (!base && [[_env objectForKey:@"scriptURL"] isKindOfClass:[NSURL class]]) {
+        base = [_env objectForKey:@"scriptURL"];
+    }
     
     if ([self shouldPreprocess]) {
-        
-        if (!base && [[_env objectForKey:@"scriptURL"] isKindOfClass:[NSURL class]]) {
-            base = [_env objectForKey:@"scriptURL"];
-        }
-        
         str = [COSPreprocessor preprocessCode:str withBaseURL:base];
     }
     


### PR DESCRIPTION
not sure if there was anything not to default to the env when not preprocessing.

This was causing stack traces to be missing