### PR TITLE
Support Objective-C objects that do not support weak references

### DIFF
--- a/src/framework/mocha/MochaRuntime.m
+++ b/src/framework/mocha/MochaRuntime.m
@@ -205,7 +205,7 @@ NSString * const MOAlreadyProtectedKey = @"moAlreadyProtectedKey";
         _ctx = ctx;
         _exportedObjects = [[NSMutableDictionary alloc] init];
         _objectsToBoxes = [NSMapTable
-                           mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality
+                           mapTableWithKeyOptions:NSMapTableStrongMemory | NSMapTableObjectPointerPersonality
                            valueOptions:NSMapTableStrongMemory | NSMapTableObjectPointerPersonality];
         _frameworkSearchPaths = [[NSMutableArray alloc] initWithObjects:
                                  @"/System/Library/Frameworks",

--- a/src/framework/mocha/MochaRuntime.m
+++ b/src/framework/mocha/MochaRuntime.m
@@ -1213,12 +1213,6 @@ static void MOObject_initialize(JSContextRef ctx, JSObjectRef object) {
 static void MOObject_finalize(JSObjectRef object) {
     MOBox *private = (__bridge MOBox *)(JSObjectGetPrivate(object));
     
-    if (![private representedObjectCanary]) {
-        NSLog(@"whoa- the canary is gone!  I'm not touching this stuff. (%@)", [private representedObjectCanaryDesc]);
-        return;
-    }
-    
-    
     // debug(@"%p finalizing %ld", private, CFGetRetainCount((__bridge CFTypeRef)private));
     id o = [private representedObject];
     

--- a/src/framework/mocha/Objects/MOBox.h
+++ b/src/framework/mocha/Objects/MOBox.h
@@ -27,9 +27,6 @@
  */
 @property (strong) id representedObject;
 
-@property (weak) id representedObjectCanary;
-@property (strong) NSString *representedObjectCanaryDesc;
-
 /*!
  * @property JSObject
  * @abstract The JSObject representation of the box

--- a/src/framework/mocha/Objects/MOBox.m
+++ b/src/framework/mocha/Objects/MOBox.m
@@ -19,25 +19,4 @@
     //debug(@"MOBox dealloc releasing: '%@'", _representedObjectCanaryDesc);
 }
 
-- (void)setRepresentedObject:(id)representedObject {
-    
-    
-    //debug(@"%p set %p (%@)", self, representedObject, [representedObject isKindOfClass:[NSData class]] ? @"BIG BIT O' DATA" : representedObject);
-    
-    _representedObject = representedObject;
-    _representedObjectCanary = representedObject;
-    _representedObjectCanaryDesc = [representedObject description];
-    
-    if ([representedObject isKindOfClass:[NSData class]]) {
-        //debug(@"DATAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-        _representedObjectCanaryDesc = [NSString stringWithFormat:@"NSData object (%p)", representedObject];
-    }
-    
-}
-
-- (id)representedObject {
-    return _representedObject;
-}
-
-
 @end


### PR DESCRIPTION
Both MOBox and _objectsToBoxes use weak references for Objective-C
objects meaning neither can be used for objects that do not support
weak references (e.g., NSFont).  Either remove these weak references
or replace them with strong references to work around the problem.

Fixes #55 