### PR TITLE
improve code highlighting, support dark theme and proper tab support

### DIFF
--- a/src/editor/JSTTextView.h
+++ b/src/editor/JSTTextView.h
@@ -10,19 +10,28 @@
 
 @class NoodleLineNumberView;
 
+typedef NS_ENUM(NSUInteger, JSTTextViewTheme) {
+    JSTTextViewThemeLight = 0,
+    JSTTextViewThemeDark,
+    JSTTextViewThemeDefault = JSTTextViewThemeLight,
+};
+
 typedef void (^JSTTextViewDragHandler)(NSTextView *draggedObject, NSString *draggedLine);
 
 @interface JSTTextView : NSTextView <NSTextStorageDelegate> {
     NSDictionary            *_keywords;
-    
     NSString                *_lastAutoInsert;
+    NSSet                   *_ignoredSymbols;
 }
 
 
 @property (retain) NSDictionary *keywords;
 @property (retain) NSString *lastAutoInsert;
+@property (retain) NSSet *ignoredSymbols;
 @property (copy) JSTTextViewDragHandler numberDragHandler; // will be called continuously as a number is dragged
 
 - (void)parseCode:(id)sender;
+- (JSTTextViewTheme) theme;
+- (void)setTheme:(JSTTextViewTheme)theme;
 
 @end


### PR DESCRIPTION
- [x] improved code highlighting and support for dark theme:
  - before: ![](https://user-images.githubusercontent.com/3254314/44283033-9bb94c00-a222-11e8-9c28-eafe4644d279.png)
  - after: ![](https://user-images.githubusercontent.com/8507602/45314346-de133780-b507-11e8-8765-90f2f4d84a93.png)
- [x] proper tab support: when there is a selection, it will indent the lines in the selection instead of replacing the selection with some space. `backtab` is now also handled properly and un-indent the lines.

