### PR TITLE
fix typo in property getter selector

### DIFF
--- a/src/framework/mocha/MochaRuntime.m
+++ b/src/framework/mocha/MochaRuntime.m
@@ -1466,7 +1466,7 @@ static JSValueRef MOBoxedObject_getProperty(JSContextRef ctx, JSObjectRef object
             }
             
             if ([object respondsToSelector:getterSelector] && ![objectClass isSelectorExcludedFromMochaScript:getterSelector]) {
-                MOMethod *method = [MOMethod methodWithTarget:object selector:selector];
+                MOMethod *method = [MOMethod methodWithTarget:object selector:getterSelector];
                 JSValueRef invocationValue = MOFunctionInvoke(method, ctx, 0, NULL, exception);
                 return invocationValue;
             }


### PR DESCRIPTION
Quick repro in sketch:

```js
let sketch = require('sketch')
let document = sketch.getSelectedDocument()

console.log(document.sketchObject.documentEdited)
```
used to throws `Unable to parse method encoding for method documentEdited: of class MSDocument`.

It will now print a boolean. 

Note that properties aren't methods and as such, don't need to be called. It shouldn't break anything because methods are still matched first.